### PR TITLE
VLCTY-906: IAM role migration: move to github-actions role in Prod-CI account (from infra account)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@master
         with:
-          role-to-assume: arn:aws:iam::718537141989:role/github-actions
+          role-to-assume: ${{ vars.GH_AWS_ROLE }}
           aws-region: us-east-1
 
       # Publish to AWS codeartifact


### PR DESCRIPTION
## IAM ROLE MIGRATION PARTY 🎉
This PR updates the the role-to-assume role used in the aws-actions/configure-aws-credentials@v2 to a new role in the Prod-CI account

This consistency will help us
* make org-wide changes if we need to move it again
* uses an org env var instead of secret to keep it visible
* moves CI compontents into a consistent account, splitting it from infra use

### How was this tested?

Testing happened in this PR as part of the workflow. Any default-branch-only or label-based workflows were not tested as part of this automated change

### Notes
* This change is independent of any permissions associated with the new or old role and should be revertable if it causes any problems